### PR TITLE
fix: CI設定とSwiftLintルールの改善

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,8 @@ concurrency:
 
 jobs:
   build:
-    name: Build & Test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, macos-15]
+    name: Build & Test
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,3 @@
-# Kata Design System - SwiftLint Rules
-# Usage: Copy custom_rules section to your project's .swiftlint.yml
-
 identifier_name:
   excluded:
     - xs
@@ -14,35 +11,8 @@ identifier_name:
     - r
     - g
     - b
-    - s
-    - t
-    - c
 
 custom_rules:
-  kata_no_hardcoded_color:
-    name: "Use Kata Color Tokens"
-    regex: '\.(foregroundColor|foregroundStyle)\s*\(\s*\.(red|blue|green|yellow|white|black|gray|orange|purple|pink|cyan|mint|teal|indigo|brown|primary|secondary|accentColor)'
-    message: "Use Kata color tokens: .foreground(\\.primary)"
-    severity: warning
-
-  kata_no_color_init:
-    name: "Avoid Color Initializers"
-    regex: 'Color\s*\(\s*(red|uiColor|nsColor|hue|white|black):'
-    message: "Use Kata color tokens instead of Color initializers"
-    severity: warning
-
-  kata_no_hardcoded_font:
-    name: "Use Kata Typography Tokens"
-    regex: '\.font\s*\(\s*\.(system|custom)\s*\('
-    message: "Use Kata typography: .textStyle(\\.body)"
-    severity: warning
-
-  kata_no_hardcoded_font_size:
-    name: "Use Kata Typography Tokens"
-    regex: '\.font\s*\(\s*\.system\s*\(\s*size:'
-    message: "Use Kata typography: .textStyle(\\.body)"
-    severity: warning
-
   kata_no_hardcoded_padding:
     name: "Use Kata Spacing Tokens"
     regex: '\.padding\s*\(\s*\d+\.?\d*\s*\)'

--- a/README.md
+++ b/README.md
@@ -208,13 +208,33 @@ let figmaTheme = Theme.standard.modified {
 
 ## SwiftLint Rules
 
-Copy `.swiftlint.yml` custom rules to enforce Kata token usage:
+Add these custom rules to your `.swiftlint.yml` to enforce Kata token usage:
 
 ```yaml
 custom_rules:
-  kata_no_hardcoded_color:
-    regex: '\.(foregroundColor|foregroundStyle)\s*\(\s*\.(red|blue|...)'
-    message: "Use Kata color tokens: .foreground(\\.primary)"
+  kata_no_hardcoded_padding:
+    name: "Use Kata Spacing Tokens"
+    regex: '\.padding\s*\(\s*\d+\.?\d*\s*\)'
+    message: "Use Kata spacing: .padding(\\.md)"
+    severity: warning
+
+  kata_no_hardcoded_padding_edges:
+    name: "Use Kata Spacing Tokens"
+    regex: '\.padding\s*\(\s*\.(all|horizontal|vertical|top|bottom|leading|trailing)\s*,\s*\d+\.?\d*\s*\)'
+    message: "Use Kata spacing: .padding(\\.md, edges: .horizontal)"
+    severity: warning
+
+  kata_no_hardcoded_radius:
+    name: "Use Kata Radius Tokens"
+    regex: '\.cornerRadius\s*\(\s*\d+\.?\d*\s*\)'
+    message: "Use Kata radius: .cornerRadius(\\.md)"
+    severity: warning
+
+  kata_no_hardcoded_frame_spacing:
+    name: "Use Kata Spacing Tokens"
+    regex: '(VStack|HStack|LazyVStack|LazyHStack)\s*\(\s*spacing\s*:\s*\d+\.?\d*\s*\)'
+    message: "Consider using Kata spacing tokens for consistency"
+    severity: warning
 ```
 
 ## Requirements

--- a/Tests/KataTests/KataTests.swift
+++ b/Tests/KataTests/KataTests.swift
@@ -78,15 +78,15 @@ import SwiftUI
 }
 
 @Test func spacingValuesAreOrdered() {
-    let s = Spacing.standard
-    #expect(s.none < s.xxs)
-    #expect(s.xxs < s.xs)
-    #expect(s.xs < s.sm)
-    #expect(s.sm < s.md)
-    #expect(s.md < s.lg)
-    #expect(s.lg < s.xl)
-    #expect(s.xl < s.xxl)
-    #expect(s.xxl < s.xxxl)
+    let spacing = Spacing.standard
+    #expect(spacing.none < spacing.xxs)
+    #expect(spacing.xxs < spacing.xs)
+    #expect(spacing.xs < spacing.sm)
+    #expect(spacing.sm < spacing.md)
+    #expect(spacing.md < spacing.lg)
+    #expect(spacing.lg < spacing.xl)
+    #expect(spacing.xl < spacing.xxl)
+    #expect(spacing.xxl < spacing.xxxl)
 }
 
 // MARK: - Radius Tests
@@ -104,31 +104,31 @@ import SwiftUI
 }
 
 @Test func radiusValuesAreOrdered() {
-    let r = Radius.standard
-    #expect(r.none < r.xs)
-    #expect(r.xs < r.sm)
-    #expect(r.sm < r.md)
-    #expect(r.md < r.lg)
-    #expect(r.lg < r.xl)
-    #expect(r.xl < r.xxl)
-    #expect(r.xxl < r.full)
+    let radius = Radius.standard
+    #expect(radius.none < radius.xs)
+    #expect(radius.xs < radius.sm)
+    #expect(radius.sm < radius.md)
+    #expect(radius.md < radius.lg)
+    #expect(radius.lg < radius.xl)
+    #expect(radius.xl < radius.xxl)
+    #expect(radius.xxl < radius.full)
 }
 
 // MARK: - Typography Tests
 
 @Test func typographyStandardHasAllStyles() {
-    let t = Typography.standard
-    #expect(t.largeTitle == .largeTitle)
-    #expect(t.title == .title)
-    #expect(t.title2 == .title2)
-    #expect(t.title3 == .title3)
-    #expect(t.headline == .headline)
-    #expect(t.subheadline == .subheadline)
-    #expect(t.body == .body)
-    #expect(t.callout == .callout)
-    #expect(t.footnote == .footnote)
-    #expect(t.caption == .caption)
-    #expect(t.caption2 == .caption2)
+    let typography = Typography.standard
+    #expect(typography.largeTitle == .largeTitle)
+    #expect(typography.title == .title)
+    #expect(typography.title2 == .title2)
+    #expect(typography.title3 == .title3)
+    #expect(typography.headline == .headline)
+    #expect(typography.subheadline == .subheadline)
+    #expect(typography.body == .body)
+    #expect(typography.callout == .callout)
+    #expect(typography.footnote == .footnote)
+    #expect(typography.caption == .caption)
+    #expect(typography.caption2 == .caption2)
 }
 
 // MARK: - Colors Tests
@@ -138,11 +138,11 @@ import SwiftUI
 }
 
 @Test func colorsSemanticColors() {
-    let c = Colors.standard
-    #expect(c.error == .red)
-    #expect(c.success == .green)
-    #expect(c.warning == .yellow)
-    #expect(c.info == .blue)
+    let colors = Colors.standard
+    #expect(colors.error == .red)
+    #expect(colors.success == .green)
+    #expect(colors.warning == .yellow)
+    #expect(colors.info == .blue)
 }
 
 // MARK: - Color Hex Tests


### PR DESCRIPTION
## 変更内容

### CI
- matrix削除、`macos-15`のみに簡素化（並列実行の意味がないため）

### SwiftLint
- 色・フォント系ルールを削除（誤検出が多いため）
  - `kata_no_hardcoded_color`
  - `kata_no_color_init`
  - `kata_no_hardcoded_font`
  - `kata_no_hardcoded_font_size`
- 数値ハードコード系ルールのみ残す
  - `kata_no_hardcoded_padding`
  - `kata_no_hardcoded_padding_edges`
  - `kata_no_hardcoded_radius`
  - `kata_no_hardcoded_frame_spacing`
- `identifier_name.excluded`から`s`, `t`, `c`を削除

### テスト
- 変数名を改善 (`s`→`spacing`, `r`→`radius`, `t`→`typography`, `c`→`colors`)

### README
- SwiftLintルールセクションを更新（コピー用ルールを追加）